### PR TITLE
Add trade-size distribution analysis and retail trading insights

### DIFF
--- a/trade-size-distribution.svg
+++ b/trade-size-distribution.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -36 760 286" role="img" aria-label="Fees vs trade volume across a logarithmic trade-size axis; retail volume upside highlighted">
+  <!-- Extracted from the Open Trader investor pitch deck (slide 9).
+       Colors resolved from investor.css: accent #c0392b, muted #7a6058,
+       faint #b09888, border #e8d4c4, text #1c1410, bg #fffaf5 -->
+  <style>
+    .chart-axis { stroke: #e8d4c4; stroke-width: 1; }
+    .chart-grid { stroke: #e8d4c4; stroke-width: 1; stroke-dasharray: 2 4; opacity: 0.7; }
+    .chart-lbl { font-family: 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; fill: #7a6058; }
+    .chart-val { font-family: 'Lora', Georgia, 'Times New Roman', serif; font-size: 13px; font-weight: 600; fill: #1c1410; }
+    .chart-val-hi { fill: #c0392b; }
+  </style>
+  <rect x="0" y="-36" width="760" height="286" fill="#fffaf5"/>
+  <!-- chart title -->
+  <text x="60" y="-18" class="chart-val" style="font-size:13px">Fees vs trade volume across trade size</text>
+  <text x="60" y="-4" class="chart-lbl" style="fill:#b09888;font-size:9.5px">8-exchange blend, spot : perp &#8776; 12 : 88 &#183; trade-size axis is logarithmic</text>
+  <!-- cohort header strip -->
+  <text x="170" y="16" text-anchor="middle" class="chart-lbl" style="fill:#b09888;font-size:9px">BELOW ICP &#183; &lt;$100</text>
+  <text x="421" y="16" text-anchor="middle" class="chart-val chart-val-hi" style="font-size:11px">FULL-FEE RETAIL &#183; $100&#8211;$50K &#183; our unit &#10003;</text>
+  <text x="641" y="16" text-anchor="middle" class="chart-lbl" style="fill:#7a6058;font-size:9px">INSTITUTIONAL &#183; &gt;$50K</text>
+  <!-- cohort bands ($100 and $50K boundaries) -->
+  <rect x="60"  y="30" width="220" height="170" fill="rgba(176,152,136,0.07)"/>
+  <rect x="280" y="30" width="283" height="170" fill="rgba(212,84,122,0.14)"/>
+  <rect x="563" y="30" width="157" height="170" fill="rgba(207,124,82,0.07)"/>
+  <line x1="280" y1="30" x2="280" y2="200" class="chart-grid"/>
+  <line x1="563" y1="30" x2="563" y2="200" style="stroke:#7a6058;stroke-width:1;stroke-dasharray:3 3;opacity:0.6"/>
+  <!-- y gridlines + labels -->
+  <line x1="60" y1="143.3" x2="720" y2="143.3" class="chart-grid"/>
+  <line x1="60" y1="86.7"  x2="720" y2="86.7"  class="chart-grid"/>
+  <text x="52" y="203" text-anchor="end" class="chart-lbl">0%</text>
+  <text x="52" y="147" text-anchor="end" class="chart-lbl">15%</text>
+  <text x="52" y="90"  text-anchor="end" class="chart-lbl">30%</text>
+  <text x="52" y="34"  text-anchor="end" class="chart-lbl">45%</text>
+  <!-- decade gridlines (log) -->
+  <line x1="175" y1="30" x2="175" y2="200" class="chart-grid"/>
+  <line x1="385" y1="30" x2="385" y2="200" class="chart-grid"/>
+  <line x1="490" y1="30" x2="490" y2="200" class="chart-grid"/>
+  <line x1="595" y1="30" x2="595" y2="200" class="chart-grid"/>
+  <!-- baseline (logarithmic trade-size axis) -->
+  <line x1="60" y1="200" x2="725" y2="200" class="chart-axis" style="stroke-width:1.5"/>
+  <path d="M725 200 l-7 -3.5 v7 z" fill="#7a6058"/>
+  <!-- trade-volume curve (reference) -->
+  <path d="M 122.5 200.0 C 157.5 199.3 192.5 199.7 227.5 197.9 C 262.5 196.1 297.5 197.6 332.5 189.0 C 367.5 180.4 402.5 170.8 437.5 146.1 C 472.5 121.4 507.5 41.0 542.5 41.0 C 577.5 41.0 612.5 45.9 647.5 48.3" style="fill:none;stroke:#b09888;stroke-width:1.8;stroke-dasharray:4 4;stroke-linejoin:round;stroke-linecap:round;opacity:0.75"/>
+  <!-- our-fees curve -->
+  <path d="M 122.5 200.0 C 157.5 199.7 192.5 200.0 227.5 197.5 C 262.5 195.0 297.5 190.2 332.5 164.2 C 367.5 138.1 402.5 43.9 437.5 41.2 C 472.5 38.5 507.5 38.5 542.5 38.5 C 577.5 38.5 612.5 133.3 647.5 180.7" style="fill:none;stroke:#c0392b;stroke-width:3;stroke-linejoin:round;stroke-linecap:round"/>
+  <g fill="#c0392b"><circle cx="227.5" cy="197.5" r="2.6"/><circle cx="332.5" cy="164.2" r="2.6"/><circle cx="437.5" cy="41.2" r="3.4"/><circle cx="542.5" cy="38.5" r="3.4"/><circle cx="647.5" cy="180.7" r="2.6"/></g>
+  <!-- value labels -->
+  <text x="332.5" y="159" text-anchor="middle" class="chart-lbl" style="fill:#c0392b;font-weight:700;font-size:9px">9%</text>
+  <text x="437.5" y="35"  text-anchor="middle" class="chart-val chart-val-hi" style="font-size:11px">42%</text>
+  <text x="542.5" y="32"  text-anchor="middle" class="chart-val chart-val-hi" style="font-size:11px">43%</text>
+  <text x="647.5" y="176" text-anchor="middle" class="chart-lbl" style="fill:#c0392b;font-weight:700;font-size:9px">5%</text>
+  <text x="600" y="60" text-anchor="middle" class="chart-lbl" style="fill:#b09888;font-weight:700;font-size:9px">40% vol</text>
+  <!-- UPSIDE: retail volume should grow -->
+  <path d="M 300 178 L 300 96" stroke="#c0392b" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M 300 84 l -8 15 h 16 z" fill="#c0392b"/>
+  <text x="300" y="76" text-anchor="middle" class="chart-val chart-val-hi" style="font-size:10px">retail volume &#8593;</text>
+  <text x="300" y="66" text-anchor="middle" class="chart-lbl" style="fill:#b09888;font-size:8px">untapped upside</text>
+  <!-- decade tick labels (powers of ten) -->
+  <g class="chart-lbl" style="font-size:10px">
+    <text x="70"  y="216" text-anchor="middle">$1</text>
+    <text x="175" y="216" text-anchor="middle">$10</text>
+    <text x="280" y="216" text-anchor="middle">$100</text>
+    <text x="385" y="216" text-anchor="middle">$1K</text>
+    <text x="490" y="216" text-anchor="middle">$10K</text>
+    <text x="595" y="216" text-anchor="middle">$100K</text>
+    <text x="700" y="216" text-anchor="middle">$1M</text>
+  </g>
+  <text x="725" y="231" text-anchor="end" class="chart-lbl" style="fill:#b09888;font-size:9px">trade size, log scale &#8594;</text>
+  <!-- legend -->
+  <line x1="424" y1="240" x2="446" y2="240" style="stroke:#c0392b;stroke-width:3"/>
+  <text x="451" y="243" class="chart-lbl" style="font-size:9px">our fees</text>
+  <line x1="528" y1="240" x2="550" y2="240" style="stroke:#b09888;stroke-width:1.8;stroke-dasharray:4 4"/>
+  <text x="555" y="243" class="chart-lbl" style="font-size:9px">trade volume</text>
+</svg>

--- a/why-retail-still-trades-by-hand.md
+++ b/why-retail-still-trades-by-hand.md
@@ -1,0 +1,40 @@
+# Why Most Crypto Traders Still Trade by Hand
+
+> **Date:** August 2026
+> **Based on:** [Exchange Liquidity & Market Microstructure Research — BTCUSDT](exchange-liquidity-research.md) (own measurements via public exchange APIs, Binance / Bybit / OKX)
+
+If you record every trade that happens on a big crypto exchange and sort them by size, the sizes alone tell you a surprising amount about the *people* behind them. That is what we did — and the shape of the result leads to a simple, slightly unexpected conclusion: **most retail traders still trade manually, with their whole deposit, in a visual UI.**
+
+Here is the picture, taken from our investor deck and built on the measurements:
+
+![Fees vs trade volume across trade size, logarithmic axis](trade-size-distribution.svg)
+
+The dashed line shows where the traded money actually is, across trade sizes from $1 to $1M (the axis is logarithmic — each step is 10×). The solid line is the modeled fee revenue of a retail-focused platform across the same sizes. Three things stand out.
+
+## 1. Small trades are many — big trades carry the money
+
+On spot BTCUSDT, trades under $100 make up roughly two-thirds of all trades, but only about 1.5% of the money. At the other end, trades of $10k–$50k are under 2% of all trades — yet they carry a third of the turnover. This is a classic Pareto (power-law) shape, the same one that describes how wealth itself is distributed. That's also why we trust the shape: it isn't an accident of one measurement window. It comes from how much money the participants have, and that doesn't change overnight.
+
+## 2. The bulge sits exactly at "whole deposit" size
+
+Typical retail deposits are around $1k–$5k. On spot, the volume bulge sits at $1k–$5k tickets. On perpetual futures, where retail commonly uses 10–20× leverage, the bulge moves to $10k–$100k — which is exactly $1k–$5k **multiplied by the leverage**.
+
+In other words: the trades we see are the size of *entire deposits*. People are not trading small slices of their account. They put the whole thing into one order, in one click.
+
+## 3. Exchanges price this in
+
+The fee schedules follow the same picture. Small and mid-size traders sit at the base tier and pay full fees. Really large players get steep VIP discounts — exchanges give margin away to keep the mobile, professional flow from leaving. That is why the solid fee line collapses on the right side of the chart even though the volume there stays high: the whales trade a lot, but pay almost nothing per dollar.
+
+## What this adds up to
+
+Any decent trading algorithm — even a basic one — splits a large order into many smaller pieces. It does this for boring, universal reasons: less price impact, staged entries, hidden intentions, controlled risk. Splitting is the *first* thing automation does.
+
+But the data shows the opposite: retail-sized volume arrives as single, whole-deposit orders. There is no trace of systematic splitting at that scale. Which means there is no automation layer between those traders and the order book.
+
+So the chain is short:
+
+whole-deposit orders → no splitting → no trading bots → **manual trading in a visual interface**.
+
+To be clear, this is not a mathematical proof — it is a fact-supported reading of the data. Some of the mid-size trades are certainly large players slicing their orders, and at retail sizes splitting is also simply less necessary (a $30k order is invisible on a liquid pair). But every signature in the data points the same way, and it matches what everyone in the industry quietly knows: below the institutional tier, algorithmic trading is rare, and the exchange app with a buy button is still the main instrument.
+
+That is the gap the [Open Trader](https://github.com/l2xl/open-trader) project is built for: millions of traders whose position size is already bounded by their deposit — and whose only remaining lever is automating their attention.


### PR DESCRIPTION
## Summary
This PR adds documentation and visualization assets that analyze crypto exchange trade patterns to support the thesis that most retail traders still trade manually without algorithmic splitting.

## Changes
- **trade-size-distribution.svg**: New chart visualization showing the relationship between fees and trade volume across logarithmic trade sizes ($1–$1M). The chart includes:
  - Three trader cohorts: below-ICP (<$100), full-fee retail ($100–$50K), and institutional (>$50K)
  - Fee revenue curve (solid red line) vs. trade volume curve (dashed muted line)
  - Highlighted retail volume upside opportunity
  - Logarithmic x-axis with decade gridlines and proper axis labeling
  - Color scheme and typography matching the investor deck design system

- **why-retail-still-trades-by-hand.md**: New analysis document that:
  - Interprets the trade-size distribution data to identify behavioral patterns
  - Demonstrates that volume bulges align with typical retail deposit sizes ($1k–$5k on spot, $10k–$100k on leveraged perpetuals)
  - Argues that the absence of order splitting at retail scale indicates manual trading without algorithmic automation
  - Connects the findings to the Open Trader project's value proposition

## Key Insights
The analysis reveals that retail-sized trades arrive as single, whole-deposit orders without systematic splitting—a signature of manual trading rather than algorithmic execution. This gap represents the core opportunity for automated trading tools targeting retail traders whose position sizing is already constrained by their account balance.

https://claude.ai/code/session_016jQsbBMqZJPhiG4Wo8wrSC